### PR TITLE
fix: removed unnecessary SDK check 

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogDarkFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogDarkFragment.kt
@@ -25,14 +25,22 @@ abstract class BottomSheetDialogDarkFragment : BottomSheetDialogLightFragment() 
     // dark theme, but with light navigation bar
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
+                dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
+            }
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
+                dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                     View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
                     View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-            dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
-        } else {
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
+                dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
+            }
+            else -> {
+                dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
+            }
         }
     }
 }

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogDarkFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogDarkFragment.kt
@@ -25,7 +25,7 @@ abstract class BottomSheetDialogDarkFragment : BottomSheetDialogLightFragment() 
     // dark theme, but with light navigation bar
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                     View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
                     View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogLightFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogLightFragment.kt
@@ -80,7 +80,7 @@ abstract class BottomSheetDialogLightFragment : BottomSheetDialogFragment() {
     // light theme
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                 View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
                 View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogLightFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogLightFragment.kt
@@ -80,14 +80,22 @@ abstract class BottomSheetDialogLightFragment : BottomSheetDialogFragment() {
     // light theme
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-                View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
-                View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or
-                View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-        } else {
-            dialog?.window?.decorView?.systemUiVisibility =
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
+                dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            }
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
+                dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or
+                    View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            }
+            else -> {
+                dialog?.window?.decorView?.systemUiVisibility =
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            }
         }
         dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
     }

--- a/app/src/main/java/it/ministerodellasalute/immuni/util/ProgressDialogFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/util/ProgressDialogFragment.kt
@@ -50,10 +50,8 @@ internal class ProgressDialogFragment : DialogFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            dialog?.window?.statusBarColor = Color.TRANSPARENT
-        }
+        dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        dialog?.window?.statusBarColor = Color.TRANSPARENT
 
         // show message if available
         arguments?.getString(MESSAGE)?.let {


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description
In **ProgressDialogFragment.kt** the SDK check:
```kotlin
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
    dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
    dialog?.window?.statusBarColor = Color.TRANSPARENT
}
```
is unnecessary because the `minSdkVersion` is 23.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:


