### PR TITLE
fix: remove unnecessary SDK check

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/util/ProgressDialogFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/util/ProgressDialogFragment.kt
@@ -50,10 +50,8 @@ internal class ProgressDialogFragment : DialogFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            dialog?.window?.statusBarColor = Color.TRANSPARENT
-        }
+        dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        dialog?.window?.statusBarColor = Color.TRANSPARENT
 
         // show message if available
         arguments?.getString(MESSAGE)?.let {


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description
In **ProgressDialogFragment.kt** the SDK check:

```kotlin
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
    dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
    dialog?.window?.statusBarColor = Color.TRANSPARENT
}
```
is unnecessary because the minSdkVersion is 23.

<!--- Describe in detail the proposed mods -->

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

