### PR TITLE
fix: Do not fallback to a plain http URL in PlayStoreActions

### DIFF
--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/playstore/PlayStoreActions.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/playstore/PlayStoreActions.kt
@@ -46,7 +46,7 @@ object PlayStoreActions {
         } catch (e: ActivityNotFoundException) {
             val intent = Intent(
                 Intent.ACTION_VIEW,
-                Uri.parse("http://play.google.com/store/apps/details?id=" + (appPackage ?: context.packageName))
+                Uri.parse("https://play.google.com/store/apps/details?id=" + (appPackage ?: context.packageName))
             )
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)


### PR DESCRIPTION
## Description

Seems like `PlayStoreActions` is using as fallback a plain `http://` URL
if the `market://` intent fails to resolve.

I've checked all the other occurrences and they're fine.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] (N/A) The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] (N/A) I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

Fixes #46
Closes #47 