### PR TITLE
fix: log only in debug builds

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -23,7 +23,7 @@ export default async () => {
 
   await commitLint({ enabled: true, allowedScopes: [] });
 
-  await kotlinLint("app/src/main/java/org/immuni/android/");
-  await kotlinLint("debugmenu/src/main/java/org/immuni/android");
-  await kotlinLint("extensions/src/main/java/org/immuni/android");
+  await kotlinLint("app/src/main/java/it/ministerodellasalute/immuni");
+  await kotlinLint("debugmenu/src/main/java/it/ministerodellasalute/immuni");
+  await kotlinLint("extensions/src/main/java/it/ministerodellasalute/immuni");
 };

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/Log.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/Log.kt
@@ -19,7 +19,7 @@ import android.util.Log
 import it.ministerodellasalute.immuni.extensions.BuildConfig
 
 fun Any.log(msg: String, tag: String = this::class.java.simpleName) {
-    if(BuildConfig.DEBUG) {
+    if (BuildConfig.DEBUG) {
         Log.d(tag, msg)
     }
 }

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/Log.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/Log.kt
@@ -16,7 +16,10 @@
 package it.ministerodellasalute.immuni.extensions.utils
 
 import android.util.Log
+import it.ministerodellasalute.immuni.extensions.BuildConfig
 
-fun log(msg: String) {
-    Log.d("Immuni", msg)
+fun Any.log(msg: String, tag: String = this::class.java.simpleName) {
+    if(BuildConfig.DEBUG) {
+        Log.d(tag, msg)
+    }
 }

--- a/network/src/main/java/it/ministerodellasalute/immuni/network/api/NetworkRetrofit.kt
+++ b/network/src/main/java/it/ministerodellasalute/immuni/network/api/NetworkRetrofit.kt
@@ -18,6 +18,7 @@ package it.ministerodellasalute.immuni.network.api
 import android.content.Context
 import android.util.Log
 import com.squareup.moshi.Moshi
+import it.ministerodellasalute.immuni.network.BuildConfig
 import it.ministerodellasalute.immuni.network.NetworkConfiguration
 import okhttp3.Cache
 import okhttp3.Interceptor
@@ -45,7 +46,9 @@ class NetworkRetrofit(
 
     val client by lazy {
         val builder = OkHttpClient.Builder()
-        builder.addInterceptor(loggingInterceptor)
+        if(BuildConfig.DEBUG) {
+            builder.addInterceptor(loggingInterceptor)
+        }
 
         /**
          * uncomment this line to verify if http cache is working

--- a/network/src/main/java/it/ministerodellasalute/immuni/network/api/NetworkRetrofit.kt
+++ b/network/src/main/java/it/ministerodellasalute/immuni/network/api/NetworkRetrofit.kt
@@ -46,14 +46,14 @@ class NetworkRetrofit(
 
     val client by lazy {
         val builder = OkHttpClient.Builder()
-        if(BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG) {
             builder.addInterceptor(loggingInterceptor)
         }
 
         /**
          * uncomment this line to verify if http cache is working
          * network interceptor is not called when the cache is used.
-        **/
+         **/
         // builder.addNetworkInterceptor(loggingInterceptor)
 
         certificatePinner?.let {


### PR DESCRIPTION
## Description

Disable production logs for security reason.

This PR tackles:

- add handy log extension function
- disable logging in release builds

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
