### PR TITLE
fix: Remove several unnecessary API Level checks

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/util/ProgressDialogFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/util/ProgressDialogFragment.kt
@@ -50,10 +50,8 @@ internal class ProgressDialogFragment : DialogFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            dialog?.window?.statusBarColor = Color.TRANSPARENT
-        }
+        dialog?.window?.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        dialog?.window?.statusBarColor = Color.TRANSPARENT
 
         // show message if available
         arguments?.getString(MESSAGE)?.let {

--- a/debugmenu/src/main/java/it/ministerodellasalute/immuni/debugmenu/item/ClearAppDataItem.kt
+++ b/debugmenu/src/main/java/it/ministerodellasalute/immuni/debugmenu/item/ClearAppDataItem.kt
@@ -24,12 +24,7 @@ import it.ministerodellasalute.immuni.debugmenu.DebugMenuItem
 class ClearAppDataItem : DebugMenuItem(
     "\uD83D\uDCA5 Clear app",
     { context, config ->
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            (context.getSystemService(ACTIVITY_SERVICE) as ActivityManager)
-                .clearApplicationUserData()
-        } else {
-            Toast.makeText(context, "This works only on Android API 19+", Toast.LENGTH_LONG)
-                .show()
-        }
+        (context.getSystemService(ACTIVITY_SERVICE) as ActivityManager)
+            .clearApplicationUserData()
     }
 )

--- a/debugmenu/src/main/java/it/ministerodellasalute/immuni/debugmenu/ui/ExitActivity.kt
+++ b/debugmenu/src/main/java/it/ministerodellasalute/immuni/debugmenu/ui/ExitActivity.kt
@@ -29,11 +29,7 @@ class ExitActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (android.os.Build.VERSION.SDK_INT >= 21) {
-            finishAndRemoveTask()
-        } else {
-            finish()
-        }
+        finishAndRemoveTask()
     }
 
     override fun onDestroy() {

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/activity/ActivityExtensions.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/activity/ActivityExtensions.kt
@@ -143,10 +143,8 @@ fun AppCompatActivity.setDarkStatusBarFullscreen(color: Int) {
 }
 
 fun AppCompatActivity.setStatusBarColor(color: Int) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-        window.statusBarColor = color
-    }
+    window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+    window.statusBarColor = color
 }
 
 fun FragmentActivity.showAlert(

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/ScreenUtils.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/ScreenUtils.kt
@@ -72,12 +72,12 @@ object ScreenUtils {
         var widthPixels = metrics.widthPixels
         var heightPixels = metrics.heightPixels
         // includes window decorations (statusbar bar/menu bar)
-        if (Build.VERSION.SDK_INT >= 14 && Build.VERSION.SDK_INT < 17) try {
+        try {
             widthPixels = Display::class.java.getMethod("getRawWidth").invoke(d) as Int
             heightPixels = Display::class.java.getMethod("getRawHeight").invoke(d) as Int
         } catch (ignored: Exception) { }
         // includes window decorations (statusbar bar/menu bar)
-        if (Build.VERSION.SDK_INT >= 17) try {
+        try {
             val realSize = Point()
             Display::class.java.getMethod("getRealSize", Point::class.java)
                 .invoke(d, realSize)


### PR DESCRIPTION
## Description

The codebase contains several unnecessary API Level checks
that are not needed as the `minSdkVersion` is set to 23.

This is a follow-up to @Datalux PRs #30
Please let me know if I should rebase on top of their branch

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
