### PR TITLE
fix: Disable javascript in WebViewPopup

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/WebViewPopup.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/WebViewPopup.kt
@@ -33,8 +33,6 @@ class WebViewPopup : PopupDialogFragment() {
         val args = navArgs<WebViewPopupArgs>()
         webView.webViewClient = WebViewClient()
         webView.loadUrl(args.value.url)
-        webView.settings.javaScriptEnabled = true
-        webView.settings.javaScriptCanOpenWindowsAutomatically = false
 
         // force resize the web view to fix bottom sheet height
         webView.updateLayoutParams {


### PR DESCRIPTION
## Description

As explained in #40, this PR disables the Javascript engine for the `WebView` in `WebView` popup.

Given that the endpoints are down at the moment, I'm not able to verify if the TOS/FAQ/PP pages require JS to render properly. If that is the case, you probably want to hold-on on this PR till you find an alternative solution. 

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #40 
