### PR TITLE
fix: adds HTTPS connection in PlayStoreActions.kt

### DIFF
--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/playstore/PlayStoreActions.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/playstore/PlayStoreActions.kt
@@ -46,7 +46,7 @@ object PlayStoreActions {
         } catch (e: ActivityNotFoundException) {
             val intent = Intent(
                 Intent.ACTION_VIEW,
-                Uri.parse("http://play.google.com/store/apps/details?id=" + (appPackage ?: context.packageName))
+                Uri.parse("https://play.google.com/store/apps/details?id=" + (appPackage ?: context.packageName))
             )
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)


### PR DESCRIPTION
## Description
Ensures HTTPS is used to connect to Google Play Store, preventing MiTM attacks.

## Checklist
- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes
- Fixes #46
