### PR TITLE
Update ExposureNotificationFragment.kt

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
@@ -53,7 +53,8 @@ class ExposureNotificationFragment :
         checkSpacing()
     }
 
-    private fun canProceed(): Boolean {
-        return viewModel.isBroadcastingActive.value ?: false
-    }
+   private fun canProceed(): Boolean {
+return true;
 }
+    }
+


### PR DESCRIPTION
Fix notification "Notifiche di esposizione non attivate"

Changes line 56-58:
  private fun canProceed(): Boolean {
        return viewModel.isBroadcastingActive.value ?: false  

 to 


private fun canProceed(): Boolean {
return true;
}