### PR TITLE
fix: faq descriptions are not in HTML format, but plain text

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/faq/FaqDetailsDialogFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/faq/FaqDetailsDialogFragment.kt
@@ -37,6 +37,6 @@ class FaqDetailsDialogFragment : PopupDialogFragment() {
     private fun bindData(questionAndAnswer: QuestionAndAnswer) {
         setTitle(questionAndAnswer.question)
         question.text = questionAndAnswer.question
-        answer.text = HtmlCompat.fromHtml(questionAndAnswer.answer, HtmlCompat.FROM_HTML_MODE_LEGACY)
+        answer.text = questionAndAnswer.answer
     }
 }


### PR DESCRIPTION
## Description

This fix the FAQ descriptions not being wrapped correctly.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #68
