### PR TITLE
[WIP] [FEAT] Enable danger on forked PRs within scheduler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,12 @@ jobs:
     resource_class: small
     steps:
       - run:
+          name: "[pr_check] Stop job if DANGER_GITHUB_API_TOKEN is missing"
+          command: |
+            if [[ -z "${DANGER_GITHUB_API_TOKEN}" ]]; then
+                circleci-agent step halt
+            fi
+      - run:
           name: "[pr_check] Stop job if not running in PR"
           command: |
             if [[ -z "${CIRCLE_PULL_REQUEST}" ]]; then
@@ -302,12 +308,9 @@ jobs:
       - checkout:
           name: "[pr_check] Checkout the code"
       - setup_pr_tools
-      - fetch_config
-      - install_android_dependencies
       - run:
           name: "[pr_check] Run danger"
-          command: |
-            [ -z "${DANGER_GITHUB_API_TOKEN}" ] || yarn danger ci
+          command: yarn danger ci
 
   release:
     working_directory: ~/code
@@ -322,20 +325,29 @@ jobs:
       - post_release_changelog
 
   scheduler:
-    docker:
-      - image: cimg/python:3.7.7
+    working_directory: ~/code
+    executor: default
     resource_class: small
     steps:
       - checkout
       - run:
           name: "[scheduler] Initialize scheduler submodule"
           command: git submodule update --init
+      - run:
+          name: "[scheduler] Initialize Python runtime"
+          command: |
+            sudo apt-get update
+            sudo apt-get install python3-pip
+      - run:
+          name: "[scheduler] Setup project path"
+          command: echo "export PROJECT_PATH=$(pwd)" >> $BASH_ENV
+      - setup_pr_tools
       - restore_cache:
           name: "[scheduler] Restore Python Cache"
           keys:
-            - pip-packages-v1-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
-            - pip-packages-v1-{{ .Branch }}-
-            - pip-packages-v1-
+            - pip-packages-v2-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
+            - pip-packages-v2-{{ .Branch }}-
+            - pip-packages-v2-
       - run:
           name: "[scheduler] Install dependencies"
           working_directory: scheduler
@@ -343,14 +355,14 @@ jobs:
             PIPENV_NOSPIN: 1
             PIPENV_VENV_IN_PROJECT: 1
           command: |
-            pip install pipenv
+            pip3 install pipenv
             pipenv install
       - save_cache:
           name: "[scheduler] Save Python Cache"
           paths:
             - ~/.cache/pip
             - scheduler/.venv
-          key: pip-packages-v1-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
+          key: pip-packages-v2-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
       - run:
           name: "[scheduler] Configure scheduler"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,6 +411,10 @@ workflows:
     jobs:
       - build:
           context: android
+          filters:
+            branches:
+              ignore:
+                - /pull\/.+/
   pr_check:
     jobs:
       - pr_check:


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR improves the execution of PR checks on forked PRs. 

In the previous implementation of the scheduler system, PR checks on forked PRs were executed by identifying _unauthorised_ workflows and scheduling a re-run with the necessary settings to run Danger. However, due to limitations of CircleCI, such workflows may not be unauthorised in the first place, or may not have access to the necessary settings even after they're re-scheduled. This may result in Danger checks not being run on certain forked PRs, which limits our ability to maintain a consistent coding style and give constructive feedbacks to the community.

To solve this issue, we propose a different approach in which Danger is executed directly by the scheduler workflow for all forked PRs, regardless of the authorisation status of the original PR checks workflow. This allows us to improve our PR review process and to offer more consistent suggestions.

We also implemented improvements in the way safety checks are performed and communicated, and introduces additional checks on the integrity of the scheduler process.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [ ] I have updated the scheduler to the current master revision
- [x] It is ready for review! :rocket:
