### PR TITLE
fix: app lifecycle

### DIFF
--- a/app/src/androidTest/java/it/ministerodellasalute/immuni/nearby/KeyMatchingTests.kt
+++ b/app/src/androidTest/java/it/ministerodellasalute/immuni/nearby/KeyMatchingTests.kt
@@ -21,6 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.google.android.gms.common.api.ApiException
 import it.ministerodellasalute.immuni.extensions.file.copyInputStream
+import it.ministerodellasalute.immuni.extensions.lifecycle.AppLifecycleObserver
 import it.ministerodellasalute.immuni.extensions.nearby.ExposureNotificationClient
 import it.ministerodellasalute.immuni.extensions.nearby.ExposureNotificationManager
 import it.ministerodellasalute.immuni.extensions.nearby.ExposureNotificationManager.Delegate
@@ -64,7 +65,7 @@ class KeyMatchingTests {
         val dstFile = File(dstFolder.path + File.separator + name + ".zip")
         dstFile.copyInputStream(inputStream)
 
-        val manager = ExposureNotificationManager(context).apply {
+        val manager = ExposureNotificationManager(context, AppLifecycleObserver()).apply {
             setup(object : Delegate {
                 override suspend fun processKeys(
                     serverDate: Date,

--- a/app/src/main/java/it/ministerodellasalute/immuni/koinModule.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/koinModule.kt
@@ -171,7 +171,7 @@ val appModule = module {
         ExposureManager(
             get(),
             get(),
-            ExposureNotificationManager(androidContext()),
+            ExposureNotificationManager(androidContext(), get()),
             get(),
             get(),
             get(),

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/home/HomeListAdapter.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/home/HomeListAdapter.kt
@@ -154,7 +154,7 @@ class HomeListAdapter(
 
                     holder.lottieFg.gone()
 
-                    if(item.status != ExposureStatus.None()) {
+                    if (item.status != ExposureStatus.None()) {
                         holder.reactivate.setTint(context.getColor(R.color.grey_dark))
                     } else {
                         holder.reactivate.setTint(context.getColor(R.color.danger))

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/main/MainViewModel.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/main/MainViewModel.kt
@@ -41,7 +41,7 @@ class MainViewModel(
             appLifecycleObserver.isActive.filter { it }
         ) { broadcastingIsActive, status, isActive ->
             Triple(broadcastingIsActive, status, isActive)
-        }.onEach { (broadcastingIsActive, _,  _) ->
+        }.onEach { (broadcastingIsActive, _, _) ->
             val protectionActive = when (broadcastingIsActive) {
                 null -> null
                 else -> broadcastingIsActive && pushNotificationManager.areNotificationsEnabled()

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
@@ -46,12 +46,15 @@ class ExposureNotificationManager(
         )
     }
 
-    constructor(context: Context) : this(
+    constructor(context: Context, lifecycleObserver: AppLifecycleObserver) : this(
         locationStateFlow = LocationStateFlow(context),
         bluetoothStateFlow = BluetoothStateFlow(context),
-        lifecycleObserver = AppLifecycleObserver(),
-        exposureNotificationClient =
-        ExposureNotificationClientWrapper(Nearby.getExposureNotificationClient(context))
+        lifecycleObserver = lifecycleObserver,
+        exposureNotificationClient = ExposureNotificationClientWrapper(
+            Nearby.getExposureNotificationClient(
+                context
+            )
+        )
     )
 
     companion object {


### PR DESCRIPTION
## Description

The Exposure Manger used a separated app lifecycle object causing the SDK state to not be triggered.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #86
