### PR TITLE
fix: make app robust to eventual future language additions

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
@@ -52,7 +52,6 @@ data class ConfigurationSettings(
     @field:Json(name = "dummy_teks_request_probabilities") val dummyTeksRequestProbabilities: List<Double>,
     @field:Json(name = "teks_max_summary_count") val teksMaxSummaryCount: Int,
     @field:Json(name = "teks_max_info_count") val teksMaxInfoCount: Int,
-    @field:Json(name = "support_email") val supportEmail: String = defaultSettings.supportEmail
     @field:Json(name = "teks_packet_size") val teksPacketSize: Int
 )
 
@@ -107,7 +106,6 @@ private fun languageMap(map: (Language) -> String): Map<String, String> {
 // FIXME define sensible defaults!
 val defaultSettings = ConfigurationSettings(
     minimumBuildVersion = 0,
-    supportEmail = "",
     faqUrls = languageMap { "https://get.immuni.gov.it/docs/faq-${it.code}.json" },
     termsOfUseUrls = languageMap { "https://get.immuni.gov.it/docs/app-tou-${it.code}.html" },
     privacyNoticeUrls = languageMap { "https://get.immuni.gov.it/docs/app-pn-${it.code}.html" },

--- a/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
@@ -37,9 +37,9 @@ interface ConfigurationSettingsService {
 @JsonClass(generateAdapter = true)
 data class ConfigurationSettings(
     @field:Json(name = "minimum_build_version") val minimumBuildVersion: Int,
-    @field:Json(name = "faq_url") val faqUrls: Map<Language, String>,
-    @field:Json(name = "tou_url") val termsOfUseUrls: Map<Language, String>,
-    @field:Json(name = "pn_url") val privacyNoticeUrls: Map<Language, String>,
+    @field:Json(name = "faq_url") val faqUrls: Map<String, String>,
+    @field:Json(name = "tou_url") val termsOfUseUrls: Map<String, String>,
+    @field:Json(name = "pn_url") val privacyNoticeUrls: Map<String, String>,
     @field:Json(name = "exposure_configuration") val exposureConfiguration: ExposureConfiguration,
     @field:Json(name = "service_not_active_notification_period") val serviceNotActiveNotificationPeriod: Int,
     @field:Json(name = "onboarding_not_completed_notification_period") val onboardingNotCompletedNotificationPeriod: Int,
@@ -52,8 +52,8 @@ data class ConfigurationSettings(
     @field:Json(name = "dummy_teks_request_probabilities") val dummyTeksRequestProbabilities: List<Double>,
     @field:Json(name = "teks_max_summary_count") val teksMaxSummaryCount: Int,
     @field:Json(name = "teks_max_info_count") val teksMaxInfoCount: Int,
-    @field:Json(name = "teks_packet_size") val teksPacketSize: Int,
     @field:Json(name = "support_email") val supportEmail: String = defaultSettings.supportEmail
+    @field:Json(name = "teks_packet_size") val teksPacketSize: Int
 )
 
 @JsonClass(generateAdapter = true)
@@ -98,43 +98,19 @@ enum class Language(val code: String) {
     }
 }
 
-private fun languageMap(map: (Language) -> String): Map<Language, String> {
+private fun languageMap(map: (Language) -> String): Map<String, String> {
     return mapOf(*Language.values().map { language ->
-        language to map(language)
+        language.name to map(language)
     }.toTypedArray())
 }
 
 // FIXME define sensible defaults!
 val defaultSettings = ConfigurationSettings(
     minimumBuildVersion = 0,
-    faqUrls = languageMap { language ->
-        when (language) {
-            EN -> ""
-            IT -> ""
-            DE -> ""
-            FR -> ""
-            ES -> ""
-        }
-    },
-    termsOfUseUrls = languageMap { language ->
-        when (language) {
-            EN -> ""
-            IT -> ""
-            DE -> ""
-            FR -> ""
-            ES -> ""
-        }
-    },
-    privacyNoticeUrls = languageMap { language ->
-        when (language) {
-            EN -> ""
-            IT -> ""
-            DE -> ""
-            FR -> ""
-            ES -> ""
-        }
-    },
     supportEmail = "",
+    faqUrls = languageMap { "https://get.immuni.gov.it/docs/faq-${it.code}.json" },
+    termsOfUseUrls = languageMap { "https://get.immuni.gov.it/docs/app-tou-${it.code}.html" },
+    privacyNoticeUrls = languageMap { "https://get.immuni.gov.it/docs/app-pn-${it.code}.html" },
     exposureConfiguration = ExposureConfiguration(
         attenuationThresholds = listOf(50, 70),
         attenuationScores = listOf(1, 2, 3, 4, 5, 6, 7, 8),

--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/settings/ConfigurationSettingsManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/settings/ConfigurationSettingsManager.kt
@@ -103,8 +103,8 @@ class ConfigurationSettingsManager(
 
     private fun fetchFaqsAsync(): Deferred<FetchFaqsResult> {
         return scope.async {
-            val language = if (settings.value.faqUrls.containsKey(currentLanguage)) currentLanguage else Language.EN
-            val url = settings.value.faqUrls[language] ?: return@async FetchFaqsResult.ServerError
+            val language = if (settings.value.faqUrls.containsKey(currentLanguage.code)) currentLanguage else Language.EN
+            val url = settings.value.faqUrls[language.code] ?: return@async FetchFaqsResult.ServerError
             val result = networkRepository.fetchFaqs(url)
             if (result is FetchFaqsResult.Success) {
                 onFaqsUpdate(language, result.faqs)
@@ -124,12 +124,12 @@ class ConfigurationSettingsManager(
     val privacyNoticeUrl: String
         get() {
             val privacyNoticeUrls = settings.value.privacyNoticeUrls
-            return privacyNoticeUrls[currentLanguage] ?: privacyNoticeUrls[Language.EN] ?: privacyNoticeUrls[Language.IT] ?: error("Missing Privacy Notice URL")
+            return privacyNoticeUrls[currentLanguage.code] ?: privacyNoticeUrls[Language.EN.code] ?: privacyNoticeUrls[Language.IT.code] ?: error("Missing Privacy Notice URL")
         }
 
     val termsOfUseUrl: String
         get() {
             val termsOfUseUrls = settings.value.termsOfUseUrls
-            return termsOfUseUrls[currentLanguage] ?: termsOfUseUrls[Language.EN] ?: termsOfUseUrls[Language.IT] ?: error("Missing Terms of Use URL")
+            return termsOfUseUrls[currentLanguage.code] ?: termsOfUseUrls[Language.EN.code] ?: termsOfUseUrls[Language.IT.code] ?: error("Missing Terms of Use URL")
         }
 }

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/settings/SettingsViewModel.kt
@@ -40,17 +40,6 @@ class SettingsViewModel(
         )
     }
 
-    fun onSupportClick(fragment: Fragment) {
-        val email = settings.supportEmail
-
-        fragment.startSendingEmail(
-            email,
-            fragment.getString(R.string.app_name),
-            "",
-            fragment.getString(R.string.settings_setting_contact_support)
-        )
-    }
-
     fun openExposureSettings(fragment: SettingsFragment) {
         fragment.startActivityForResult(
             ExposureNotificationClient.exposureNotificationSettingsIntent,

--- a/app/src/test/java/it/ministerodellasalute/immuni/logic/ConfigurationSettingsManagerTest.kt
+++ b/app/src/test/java/it/ministerodellasalute/immuni/logic/ConfigurationSettingsManagerTest.kt
@@ -87,7 +87,7 @@ class ConfigurationSettingsManagerTest {
 
         async {
             for (i in 1..5) {
-                manager.onSettingsUpdate(settings.copy(termsOfUseUrls = mapOf(Language.EN to i.toString())))
+                manager.onSettingsUpdate(settings.copy(termsOfUseUrls = mapOf(Language.EN.code to i.toString())))
                 delay(100)
             }
             deferred.cancel()


### PR DESCRIPTION
## Description

This PR makes the app robust to eventual future language additions

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
