### PR TITLE
fix: upload teks retry

### DIFF
--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
@@ -217,6 +217,10 @@ class ExposureNotificationManager(
                     tekRequestCompleter?.completeExceptionally(e)
                     tekRequestCompleter = null
                     throw e
+                } catch (e: Exception) {
+                    log("user denied permissions")
+                    optInCompleter = null
+                    throw e
                 }
             } else {
                 log("No RESOLUTION_REQUIRED in result, sending to settings")

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
@@ -219,7 +219,7 @@ class ExposureNotificationManager(
                     throw e
                 } catch (e: Exception) {
                     log("user denied permissions")
-                    optInCompleter = null
+                    tekRequestCompleter = null
                     throw e
                 }
             } else {


### PR DESCRIPTION
## Description

This PR fixes a bug where the user cannot deny the TEKs sharing permission and then retry to upload them.

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
