### PR TITLE
fix: remove accept encoding header to prevent unexpected responses

### DIFF
--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/http/TrafficAnalysisPreventionHeadersInterceptor.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/http/TrafficAnalysisPreventionHeadersInterceptor.kt
@@ -36,7 +36,6 @@ class TrafficAnalysisPreventionHeadersInterceptor : Interceptor {
             .newBuilder()
             .addHeader("User-Agent", "Immuni")
             .addHeader("Accept-Language", "en-US;q=1.0")
-            .addHeader("Accept-Encoding", "gzip")
             .build()
         return chain.proceed(request)
     }


### PR DESCRIPTION
## Description

Hardcoding this header can be dangerous because the app can receive unexpected formats.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
