### PR TITLE
fix: error in default languages map keys

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
@@ -99,7 +99,7 @@ enum class Language(val code: String) {
 
 private fun languageMap(map: (Language) -> String): Map<String, String> {
     return mapOf(*Language.values().map { language ->
-        language.name to map(language)
+        language.code to map(language)
     }.toTypedArray())
 }
 


### PR DESCRIPTION
## Description

The default maps were initialised with uppercase keys, but should be lowercase.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
