### PR TITLE
fix: truncated alert titles

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -88,7 +88,7 @@
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">20sp</item>
         <item name="android:singleLine">false</item>
-        <item name="android:maxLines">4</item>
+        <item name="android:maxLines">6</item>
     </style>
 
     <style name="AlertBodyTextStyle" parent="MaterialAlertDialog.MaterialComponents.Body.Text">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -87,6 +87,8 @@
     <style name="AlertTitleTextStyle" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">20sp</item>
+        <item name="android:singleLine">false</item>
+        <item name="android:maxLines">4</item>
     </style>
 
     <style name="AlertBodyTextStyle" parent="MaterialAlertDialog.MaterialComponents.Body.Text">


### PR DESCRIPTION
## Description

By default material alert dialogs set a maximum of 2 lines to alert titles.

This PR tackles:

- remove singleLine attribute to alert dialog titles
- set maxLines to 6 instead of 2

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes
#99 
