### PR TITLE
fix: hide OTP error message when the timer expires

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/otp/OtpFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/otp/OtpFragment.kt
@@ -79,7 +79,10 @@ class OtpFragment : Fragment(R.layout.otp_fragment) {
 
         viewModel.loading.observe(viewLifecycleOwner) {
             activity?.loading(it, ProgressDialogFragment(), Bundle().apply {
-                putString(ProgressDialogFragment.MESSAGE, getString(R.string.upload_data_verify_loading))
+                putString(
+                    ProgressDialogFragment.MESSAGE,
+                    getString(R.string.upload_data_verify_loading)
+                )
             })
         }
 

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/otp/OtpFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/otp/OtpFragment.kt
@@ -26,6 +26,7 @@ import com.google.android.material.appbar.AppBarLayout
 import it.ministerodellasalute.immuni.R
 import it.ministerodellasalute.immuni.extensions.activity.loading
 import it.ministerodellasalute.immuni.extensions.activity.setLightStatusBar
+import it.ministerodellasalute.immuni.extensions.view.gone
 import it.ministerodellasalute.immuni.extensions.view.setSafeOnClickListener
 import it.ministerodellasalute.immuni.extensions.view.visible
 import it.ministerodellasalute.immuni.util.ProgressDialogFragment
@@ -93,6 +94,7 @@ class OtpFragment : Fragment(R.layout.otp_fragment) {
             if (it == null) {
                 verify.text = getString(R.string.upload_data_verify_button)
                 verify.isEnabled = true
+                authorizationError.gone()
             } else {
                 verify.text = it
                 verify.isEnabled = false


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

Hide OTP validation error message after the timer expires.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #101
