### PR TITLE
fix: better google play services error messages

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/OnboardingViewModel.kt
@@ -19,7 +19,6 @@ import android.app.Activity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.*
 import it.ministerodellasalute.immuni.R
-import it.ministerodellasalute.immuni.extensions.activity.toast
 import it.ministerodellasalute.immuni.extensions.livedata.Event
 import it.ministerodellasalute.immuni.extensions.notifications.PushNotificationManager
 import it.ministerodellasalute.immuni.extensions.utils.ExternalLinksHelper
@@ -178,7 +177,7 @@ class OnboardingViewModel(
                 val title = activity.getString(R.string.force_update_not_available_title)
                 var message = activity.getString(R.string.force_update_not_available_message)
                 errorCode?.let { code ->
-                    message += "\n\nError code: ${code}."
+                    message += "\n\nError code: $code."
                 }
                 googlePlayServicesError.value = Pair(title, message)
             }

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/OnboardingViewModel.kt
@@ -65,6 +65,7 @@ class OnboardingViewModel(
     val skipNextPage = MutableLiveData<Event<Boolean>>()
     val isBroadcastingActive = exposureManager.isBroadcastingActive.asLiveData()
     val navigateToPrevPage = MutableLiveData<Event<Boolean>>()
+    val googlePlayServicesError = MutableLiveData<Pair<String, String>>()
 
     init {
         userManager.user.value?.region?.let {
@@ -153,11 +154,33 @@ class OnboardingViewModel(
             try {
                 exposureManager.optInAndStartExposureTracing(activity)
             } catch (e: Exception) {
-                toast(
-                    activity.applicationContext,
-                    activity.getString(R.string.onboarding_exposure_api_not_activated)
-                )
                 e.printStackTrace()
+
+                val errorCode: String? = when {
+                    // The hardware capability of the device was not supported
+                    // (missing bluetooth multi-cast or BLE support altogether).
+                    e.message?.contains("39501") == true -> {
+                        "39501"
+                    }
+                    // The client is unauthorized to access the APIs (wrong SHA256 or package name).
+                    e.message?.contains("39507") == true -> {
+                        "39507"
+                    }
+                    // The client has been rate limited for access to this API.
+                    e.message?.contains("39508") == true -> {
+                        "39508"
+                    }
+                    else -> {
+                        null
+                    }
+                }
+
+                val title = activity.getString(R.string.force_update_not_available_title)
+                var message = activity.getString(R.string.force_update_not_available_message)
+                errorCode?.let { code ->
+                    message += "\n\nError code: ${code}."
+                }
+                googlePlayServicesError.value = Pair(title, message)
             }
         }
     }

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
@@ -18,6 +18,7 @@ package it.ministerodellasalute.immuni.ui.onboarding.fragments.viewpager
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import it.ministerodellasalute.immuni.R
 import it.ministerodellasalute.immuni.extensions.view.setSafeOnClickListener
 import kotlinx.android.synthetic.main.onboarding_exposure_fragment.*
@@ -34,6 +35,16 @@ class ExposureNotificationFragment :
                 handled = true
                 viewModel.onNextTap()
             }
+        })
+
+        viewModel.googlePlayServicesError.observe(viewLifecycleOwner, Observer { pair ->
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(pair.first)
+                .setMessage(pair.second)
+                .setPositiveButton(getString(R.string.onboarding_pin_advice_action)) { d, _ ->
+                    d.dismiss()
+                }
+                .show()
         })
 
         next.isEnabled = true


### PR DESCRIPTION
## Description

In some corner case scenario the device has the most recent Google Play Services installed, but the exposure notification module is not yet ready to be used. The user is blocked during the onboarding.

This PR add more specific error messages with error code to help the user, but also the developers to debug.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
