### PR TITLE
fix: enable Lottie animation in scroll view only on high end devices

### DIFF
--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/MemoryUtils.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/MemoryUtils.kt
@@ -31,13 +31,13 @@ fun getMemoryInfo(context: Context): ActivityManager.MemoryInfo {
 /**
  * Return the total RAM of the device in MB.
  */
-fun totalRam(context: Context): Long {
-    return getMemoryInfo(context).totalMem / 1000000L
+fun totalRamMB(context: Context): Long {
+    return getMemoryInfo(context).totalMem / (1024L * 1024L)
 }
 
 /**
  * Return is this device is an high end device with enough RAM.
  */
 fun highEndDevice(context: Context): Boolean {
-    return totalRam(context) > 5
+    return totalRamMB(context) > 5000
 }

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/MemoryUtils.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/MemoryUtils.kt
@@ -39,5 +39,5 @@ fun totalRam(context: Context): Long {
  * Return is this device is an high end device with enough RAM.
  */
 fun highEndDevice(context: Context): Boolean {
-    return totalRam(context) > 3500
+    return totalRam(context) > 5
 }


### PR DESCRIPTION
## Description

Lottie animation in "How it works" section are quite demanding.

In particular, this PR uses Lottie animations only on very high end devices while it shows illustrations on the other devices.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
