### PR TITLE
fix: pause animations while scrolling

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/howitworks/HowItWorksDialogFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/howitworks/HowItWorksDialogFragment.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.RecyclerView
 import it.ministerodellasalute.immuni.R
 import it.ministerodellasalute.immuni.ui.dialog.PopupRecyclerViewDialogFragment
 import kotlinx.android.synthetic.main.how_it_works_dialog.*
@@ -36,6 +37,24 @@ class HowItWorksDialogFragment : PopupRecyclerViewDialogFragment(),
         recyclerView.adapter = adapter
 
         setTitle(getString(R.string.permission_tutorial_how_immuni_works_title))
+
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                when (newState) {
+                    RecyclerView.SCROLL_STATE_IDLE -> {
+                        adapter.onIdle()
+                    }
+                }
+            }
+
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+                if (dy != 0) {
+                    adapter.onScrolling()
+                }
+            }
+        })
     }
 
     override fun onClick(item: HowItWorksItem) {

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/howitworks/HowItWorksListAdapter.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/howitworks/HowItWorksListAdapter.kt
@@ -30,6 +30,7 @@ import com.airbnb.lottie.LottieAnimationView
 import it.ministerodellasalute.immuni.R
 import it.ministerodellasalute.immuni.extensions.utils.highEndDevice
 import it.ministerodellasalute.immuni.extensions.view.setSafeOnClickListener
+import java.lang.ref.WeakReference
 import kotlin.reflect.full.primaryConstructor
 import org.koin.core.KoinComponent
 import org.koin.core.inject
@@ -45,9 +46,23 @@ class HowItWorksListAdapter(
     private val dataSource: HowItWorksDataSource by inject { parametersOf(showFaq) }
     private val data = dataSource.data
 
+    private val lottiesMap = mutableMapOf<Int, WeakReference<LottieAnimationView>>()
+
     private fun onItemClick(pos: Int) {
         if (pos != RecyclerView.NO_POSITION) {
             clickListener.onClick(data[pos])
+        }
+    }
+
+    fun onScrolling() {
+        lottiesMap.values.forEach {
+            it.get()?.pauseAnimation()
+        }
+    }
+
+    fun onIdle() {
+        lottiesMap.values.forEach {
+            it.get()?.resumeAnimation()
         }
     }
 
@@ -86,6 +101,7 @@ class HowItWorksListAdapter(
         when (holder) {
             is ImageVH -> {
                 if (highEndDevice(context)) {
+                    lottiesMap[holder.adapterPosition] = WeakReference(holder.lottieAnimation)
                     holder.lottieAnimation.playAnimation()
                 }
             }
@@ -98,6 +114,7 @@ class HowItWorksListAdapter(
         holder.itemView.setOnClickListener(null)
         when (holder) {
             is ImageVH -> {
+                lottiesMap.remove(holder.adapterPosition)
                 holder.lottieAnimation.pauseAnimation()
             }
         }

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/MemoryUtils.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/utils/MemoryUtils.kt
@@ -39,5 +39,5 @@ fun totalRamMB(context: Context): Long {
  * Return is this device is an high end device with enough RAM.
  */
 fun highEndDevice(context: Context): Boolean {
-    return totalRamMB(context) > 5000
+    return totalRamMB(context) > 2000
 }


### PR DESCRIPTION
## Description

To avoid lag we pause Lottie animation while the recycler view is scrolling.
In this way we can support animations also on low end devices.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
