### PR TITLE
Fix escape character

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,7 +89,7 @@
     <string name="onboarding_push_permission_action">Allow</string>
     <string name="onboarding_push_permission_overlay_hint">Select \'<b>Allow</b>\' in the pop-up that appears below</string>
     <string name="onboarding_pin_advice_title">Protect your device</string>
-    <string name="onboarding_pin_advice_description">The use of Immuni is strictly personal. If you haven\'t done so already, set up a PIN on your device to protect it and prevent others from accessing your data and apps, including Immuni.</string>
+    <string name="onboarding_pin_advice_description">The use of Immuni is strictly personal. If you haven't done so already, set up a PIN on your device to protect it and prevent others from accessing your data and apps, including Immuni.</string>
     <string name="onboarding_pin_advice_action">Got it</string>
     <string name="onboarding_communication_advice_title">Watch out for scam messages</string>
     <string name="onboarding_communication_advice_description">Immuni will only ever communicate with you via the app and the corresponding notifications. <b>Be wary of any text, phone call, email, or other kind of alert</b> that appears to be from Immuni, especially if it asks you for personal information.</string>


### PR DESCRIPTION
`If you haven\'t done so already` => `If you haven't done so already`

It appeared verbatim as `haven\'t done` on my phone, so I guess the escape character has to be removed? Not sure if this is the right fix. Feel free to ignore this pr if the correct fix is elsewhere.
