### PR TITLE
fix: Use the correct string for OTP verification

### DIFF
--- a/app/src/main/res/layout/otp_fragment.xml
+++ b/app/src/main/res/layout/otp_fragment.xml
@@ -227,7 +227,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="25dp"
-                        android:text="@string/upload_data_wait_operator_message"
+                        android:text="@string/upload_data_verify_message"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@+id/stepNumberThree"
                         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

The string `upload_data_wait_operator_message` is used in the last card, where the string `upload_data_verify_message` should have been used. In fact this second string is not currently used anywhere.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [ ] It is ready for review! :rocket:
