### PR TITLE
fix: eagerly initialize UserManager and WorkerManager to prevent possible crashes

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ImmuniApplication.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ImmuniApplication.kt
@@ -48,8 +48,8 @@ class ImmuniApplication : Application(), KoinComponent {
     private lateinit var debugMenu: DebugMenu
     private lateinit var lifecycleObserver: AppLifecycleObserver
     private lateinit var activityLifecycleObserver: AppActivityLifecycleCallbacks
-    private val userManager: UserManager by inject()
-    private val workerManager: WorkerManager by inject()
+    private lateinit var userManager: UserManager
+    private lateinit var workerManager: WorkerManager
 
     override fun onCreate() {
         super.onCreate()
@@ -66,6 +66,8 @@ class ImmuniApplication : Application(), KoinComponent {
         settingsManager = get()
         forceUpdateManager = get()
         exposureManager = get()
+        userManager = get()
+        workerManager = get()
 
         // register app lifecycle
         lifecycleObserver = get()


### PR DESCRIPTION


<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR fixes possible crashes due to the use of `UnsafeLazyImpl` by Koin's `inject()`, by eagerly initializing `UserManager` and `WorkerManager` in `ImmuniApplication`.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
