### PR TITLE
feat: change notifications dismiss logic

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/koinModule.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/koinModule.kt
@@ -195,6 +195,7 @@ val appModule = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     }

--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/exposure/ExposureManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/exposure/ExposureManager.kt
@@ -25,6 +25,8 @@ import it.ministerodellasalute.immuni.logic.exposure.models.ExposureSummary
 import it.ministerodellasalute.immuni.logic.exposure.models.OtpToken
 import it.ministerodellasalute.immuni.logic.exposure.models.OtpValidationResult
 import it.ministerodellasalute.immuni.logic.exposure.repositories.*
+import it.ministerodellasalute.immuni.logic.notifications.AppNotificationManager
+import it.ministerodellasalute.immuni.logic.notifications.NotificationType
 import it.ministerodellasalute.immuni.logic.settings.ConfigurationSettingsManager
 import it.ministerodellasalute.immuni.logic.settings.models.ConfigurationSettings
 import it.ministerodellasalute.immuni.logic.user.repositories.UserRepository
@@ -39,7 +41,8 @@ class ExposureManager(
     private val userRepository: UserRepository,
     private val exposureReportingRepository: ExposureReportingRepository,
     private val exposureIngestionRepository: ExposureIngestionRepository,
-    private val exposureStatusRepository: ExposureStatusRepository
+    private val exposureStatusRepository: ExposureStatusRepository,
+    private val appNotificationManager: AppNotificationManager
 ) : ExposureNotificationManager.Delegate {
 
     private val settings get() = settingsManager.settings.value
@@ -134,10 +137,12 @@ class ExposureManager(
     suspend fun optInAndStartExposureTracing(activity: Activity) {
         stopExposureNotification()
         exposureNotificationManager.optInAndStartExposureTracing(activity)
+        appNotificationManager.removeNotification(NotificationType.ServiceNotActive)
     }
 
     suspend fun stopExposureNotification() {
         exposureNotificationManager.stopExposureNotification()
+        appNotificationManager.triggerNotification(NotificationType.ServiceNotActive)
     }
 
     suspend fun provideDiagnosisKeys(keyFiles: List<File>, token: String) {

--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/notifications/AppNotificationManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/notifications/AppNotificationManager.kt
@@ -53,7 +53,7 @@ class AppNotificationManager(val context: Context) : KoinComponent {
 
         val androidNotificationManager = NotificationManagerCompat.from(context)
         androidNotificationManager.notify(type.id, builder.build().apply {
-            flags = flags or Notification.FLAG_NO_CLEAR or Notification.FLAG_AUTO_CANCEL
+            flags = flags or Notification.FLAG_AUTO_CANCEL
         })
     }
 

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
@@ -33,7 +33,7 @@ class ExposureNotificationFragment :
         viewModel.isBroadcastingActive.observe(viewLifecycleOwner, Observer { isBroadcastingActive ->
             if (!handled && isBroadcastingActive == true && this.isResumed) {
                 handled = true
-                viewModel.onNextTap()
+                navigateNext()
             }
         })
 
@@ -53,7 +53,7 @@ class ExposureNotificationFragment :
         next.setSafeOnClickListener {
 
             if (canProceed()) {
-                viewModel.onNextTap()
+                navigateNext()
             } else {
                 activity?.let {
                     viewModel.startExposureNotification(it)
@@ -62,6 +62,10 @@ class ExposureNotificationFragment :
         }
 
         checkSpacing()
+    }
+
+    private fun navigateNext() {
+        viewModel.onNextTap()
     }
 
     private fun canProceed(): Boolean {


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

Notifications are now not sticky. The user can dismiss them immediately without the need to click on them.

As soon as the user deactivate the service, a warning notification pops up. 
As soon the user re-activate the service from within the app, the notification disappears.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #200 
- Fixes #204 