### PR TITLE
fix: authors/copyright link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - [Contributing](#contributing)
   - [Contributors](#contributors)
 - [License](#license)
-  - [Authors / Copyright](#authors---copyright)
+  - [Authors / Copyright](#authors--copyright)
   - [Third-party component licenses](#third-party-component-licenses)
     - [Tools](#tools)
     - [Libraries](#libraries)


### PR DESCRIPTION
Signed-off-by: enricocid <enrico2588@gmail.com>

## Description

This little mod fixes the broken link in "authors / copyright" header.

This PR tackles: na

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

na

- Fixes na
