### PR TITLE
feat: clear notifications

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ImmuniApplication.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ImmuniApplication.kt
@@ -86,11 +86,20 @@ class ImmuniApplication : Application(), KoinComponent {
         updateForceUpdateNotificationWorker()
         updateRiskReminderWorker()
         updateInitialDiagnosisKeysRequest()
+        updateNotificationsCleanerWorker()
         log("Workers successfully started")
     }
 
     private fun updateNextDummyExposureIngestionWorker() {
         workerManager.scheduleNextDummyExposureIngestionWorker(ExistingWorkPolicy.KEEP)
+    }
+
+    private fun updateNotificationsCleanerWorker() {
+        val job = Job()
+        val scope = CoroutineScope(Dispatchers.Default + job)
+        lifecycleObserver.isInForeground.filter { it }.onEach {
+            workerManager.scheduleNotificationsCleanerWorker(withDelay = false)
+        }.launchIn(scope)
     }
 
     private fun updateOnboardingNotCompletedWorker() {

--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/worker/WorkerManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/worker/WorkerManager.kt
@@ -82,6 +82,20 @@ class WorkerManager(
         )
     }
 
+    fun scheduleNotificationsCleanerWorker(withDelay: Boolean = true) {
+        val delay = 60 * 15L // 15 minutes
+        workManager.enqueueUniqueWork(
+            "NotificationsCleanerWorker",
+            ExistingWorkPolicy.REPLACE,
+            OneTimeWorkRequest.Builder(NotificationsCleanerWorker::class.java)
+                .setInitialDelay(
+                    if (withDelay) delay else 0,
+                    TimeUnit.SECONDS
+                )
+                .build()
+        )
+    }
+
     fun scheduleServiceNotActiveNotificationWorker(policy: ExistingWorkPolicy) {
         workManager.enqueueUniqueWork(
             "ServiceNotActiveNotificationWorker",

--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/worker/WorkerManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/worker/WorkerManager.kt
@@ -20,6 +20,7 @@ import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
+import it.ministerodellasalute.immuni.BuildConfig
 import it.ministerodellasalute.immuni.extensions.utils.exponential
 import it.ministerodellasalute.immuni.logic.exposure.models.ExposureStatus
 import it.ministerodellasalute.immuni.logic.notifications.AppNotificationManager
@@ -83,7 +84,12 @@ class WorkerManager(
     }
 
     fun scheduleNotificationsCleanerWorker(withDelay: Boolean = true) {
-        val delay = 60 * 15L // 15 minutes
+
+        val delay = when (BuildConfig.DEBUG) {
+            true -> 10L // 10 seconds
+            else -> 60 * 15L // 15 minutes
+        }
+
         workManager.enqueueUniqueWork(
             "NotificationsCleanerWorker",
             ExistingWorkPolicy.REPLACE,

--- a/app/src/main/java/it/ministerodellasalute/immuni/workers/NotificationsCleanerWorker.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/workers/NotificationsCleanerWorker.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+ * Please refer to the AUTHORS file for more information.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.ministerodellasalute.immuni.workers
+
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import it.ministerodellasalute.immuni.R
+import it.ministerodellasalute.immuni.extensions.utils.log
+import it.ministerodellasalute.immuni.logic.forceupdate.ForceUpdateManager
+import it.ministerodellasalute.immuni.logic.notifications.AppNotificationManager
+import it.ministerodellasalute.immuni.logic.notifications.NotificationType
+import it.ministerodellasalute.immuni.logic.settings.ConfigurationSettingsManager
+import it.ministerodellasalute.immuni.logic.worker.WorkerManager
+import kotlinx.coroutines.delay
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+class NotificationsCleanerWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params), KoinComponent {
+    private val notificationManager: AppNotificationManager by inject()
+    private val workerManager: WorkerManager by inject()
+    private val settingsManager: ConfigurationSettingsManager by inject()
+    private val forceUpdateManager: ForceUpdateManager by inject()
+
+    override suspend fun doWork(): Result {
+        log("NotificationsCleanerWorker running...")
+        try {
+            notificationManager.removeNotification(NotificationType.ServiceNotActive)
+            notificationManager.removeNotification(NotificationType.ForcedVersionUpdate) //TODO
+            workerManager.scheduleNotificationsCleanerWorker()
+
+            return Result.success()
+        } catch (e: Exception) {
+            return Result.retry()
+        }
+    }
+}


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

Add a periodic worker to cleanup notifications (force update, finish onboarding and service not active).

In addition the notifications are cleaned up at every app foreground event.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
