### PR TITLE
feat: promote the fetch TEKs worker to foreground service

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/notifications/AppNotificationManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/notifications/AppNotificationManager.kt
@@ -34,6 +34,7 @@ import java.util.*
 import org.koin.core.KoinComponent
 
 class AppNotificationManager(val context: Context) : KoinComponent {
+
     companion object {
         const val CHANNEL_ID = "exposure_notification"
         const val DEBUG_CHANNEL_ID = "debug_channel"
@@ -192,6 +193,18 @@ class AppNotificationManager(val context: Context) : KoinComponent {
             val androidNotificationManager = NotificationManagerCompat.from(context)
             androidNotificationManager.createNotificationChannel(channel)
         }
+    }
+
+    fun fetchKeysForegroundNotification(): Notification {
+        createExposureNotificationChannel()
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(context.getString(R.string.app_name))
+            .setTicker(context.getString(R.string.app_name))
+            .setContentText(context.getString(R.string.home_view_service_active_title))
+            .setSmallIcon(R.drawable.ic_notification_app)
+            .setColor(ContextCompat.getColor(context, R.color.colorPrimary))
+            .setOngoing(true)
+            .build()
     }
 
     /**

--- a/app/src/main/java/it/ministerodellasalute/immuni/logic/worker/WorkerManager.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/logic/worker/WorkerManager.kt
@@ -142,9 +142,12 @@ class WorkerManager(
     }
 
     fun scheduleInitialDiagnosisKeysRequest() {
+        // Use a unique work to avoid multiple workers.
+        // Use ExistingPeriodicWorkPolicy.REPLACE to ensure that the job is rescheduled
+        // as a workaround for https://issuetracker.google.com/166292069.
         enqueueDiagnosisKeysRequest(
-            ExistingWorkPolicy.KEEP,
-            delayMinutes = SecureRandom().nextInt(2 * 60).toLong()
+            ExistingWorkPolicy.REPLACE,
+            delayMinutes = 0
         )
     }
 
@@ -167,7 +170,6 @@ class WorkerManager(
                 .setInitialDelay(delayMinutes, TimeUnit.MINUTES)
                 .setConstraints(
                     Constraints.Builder()
-                        .setRequiresBatteryNotLow(true)
                         .build()
                 )
                 .build()

--- a/app/src/main/java/it/ministerodellasalute/immuni/workers/ExposureNotificationWorkers.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/workers/ExposureNotificationWorkers.kt
@@ -17,6 +17,7 @@ package it.ministerodellasalute.immuni.workers
 
 import android.content.Context
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import it.ministerodellasalute.immuni.BuildConfig
 import it.ministerodellasalute.immuni.R
@@ -72,7 +73,18 @@ class RequestDiagnosisKeysWorker(
     private val settingsManager: ConfigurationSettingsManager by inject()
     private val notificationManager: AppNotificationManager by inject()
 
+    private val NOTIFICATION_FETCH_ID = 10001
+
     override suspend fun doWork(): Result {
+
+        // Make the worker run in a Foreground Service to reduce the chance of falling into the rare bucket
+        // https://developer.android.com/topic/performance/appstandby#rare-bucket
+        setForeground(
+            ForegroundInfo(
+                NOTIFICATION_FETCH_ID,
+                notificationManager.fetchKeysForegroundNotification()
+            )
+        )
 
         // DEBUG notification
         if (applicationContext.resources.getBoolean(R.bool.development_device)) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         // App version digits
         versionMajor = 1
-        versionMinor = 3
-        versionPatch = 1
+        versionMinor = 4
+        versionPatch = 0
 
         // Version name follows the <major>.<minor>.<patch> convention
         computeVersionName = { ->


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR tackles:

- Immediately restart the fetch TEKs worker as soon as the app start/restart/is re-opened by the user as a workaround to this [issue](https://issuetracker.google.com/166292069).
- Promote the fetch TEKs worker to foreground service

In particular, the PR reduce the chance of falling into the [rare bucket](https://developer.android.com/topic/performance/appstandby#rare-bucket) 

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [ ] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [ ] It is ready for review! :rocket:
