### PR TITLE
feat: remove location requirement for Android 11 and up

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogDarkFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogDarkFragment.kt
@@ -15,24 +15,4 @@
 
 package it.ministerodellasalute.immuni.ui.dialog
 
-import android.os.Build
-import android.os.Bundle
-import android.view.View
-import it.ministerodellasalute.immuni.R
-
-abstract class BottomSheetDialogDarkFragment : BottomSheetDialogLightFragment() {
-
-    // dark theme, but with light navigation bar
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
-                    View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-            dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
-        } else {
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
-        }
-    }
-}
+abstract class BottomSheetDialogDarkFragment : BottomSheetDialogLightFragment()

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogLightFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/dialog/BottomSheetDialogLightFragment.kt
@@ -15,52 +15,22 @@
 
 package it.ministerodellasalute.immuni.ui.dialog
 
-import android.app.Dialog
 import android.graphics.Color
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.GradientDrawable
-import android.graphics.drawable.LayerDrawable
-import android.os.Build
 import android.os.Bundle
-import android.util.DisplayMetrics
 import android.view.View
-import android.view.Window
 import android.widget.FrameLayout
-import androidx.core.graphics.drawable.toDrawable
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import it.ministerodellasalute.immuni.R
-import it.ministerodellasalute.immuni.extensions.view.getColorCompat
 
 abstract class BottomSheetDialogLightFragment : BottomSheetDialogFragment() {
 
     protected val bottomSheetBehavior: BottomSheetBehavior<FrameLayout>?
         get() = (dialog as? BottomSheetDialog)?.behavior
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog = super.onCreateDialog(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            setLightNavigationBar(dialog)
-        }
-        return dialog
-    }
-
-    // navigation bar color
-    private fun setLightNavigationBar(dialog: Dialog?) {
-        val window: Window? = dialog?.window
-        if (window != null) {
-            val metrics = DisplayMetrics()
-            window.windowManager.defaultDisplay.getMetrics(metrics)
-            val dimDrawable = requireContext().getColorCompat(R.color.popup_mask).toDrawable()
-            val navigationBarDrawable = GradientDrawable()
-            navigationBarDrawable.shape = GradientDrawable.RECTANGLE
-            navigationBarDrawable.setColor(requireContext().resources.getColor(R.color.background))
-            val layers = arrayOf<Drawable>(dimDrawable, navigationBarDrawable)
-            val windowBackground = LayerDrawable(layers)
-            windowBackground.setLayerInsetTop(1, metrics.heightPixels)
-            window.setBackgroundDrawable(windowBackground)
-        }
+    override fun getTheme(): Int {
+        return R.style.Widget_AppTheme_BottomSheet
     }
 
     // force state expanded on open
@@ -75,20 +45,5 @@ abstract class BottomSheetDialogLightFragment : BottomSheetDialogFragment() {
                 BottomSheetBehavior.from(bottomSheet!!)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
         }
-    }
-
-    // light theme
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            dialog?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-                View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
-                View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or
-                View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-        } else {
-            dialog?.window?.decorView?.systemUiVisibility =
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-        }
-        dialog?.window?.statusBarColor = resources.getColor(R.color.transparent)
     }
 }

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/main/MainActivity.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/main/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : ImmuniActivity() {
         } // Else, need to wait for onRestoreInstanceState
     }
 
-    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
         // Now that BottomNavigationBar has restored its instance state
         // and its selectedItemId, we can proceed with setting up the

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
@@ -23,6 +23,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import it.ministerodellasalute.immuni.R
 import it.ministerodellasalute.immuni.extensions.utils.DeviceUtils
+import it.ministerodellasalute.immuni.extensions.view.gone
 import it.ministerodellasalute.immuni.extensions.view.setSafeOnClickListener
 import it.ministerodellasalute.immuni.ui.onboarding.fragments.ViewPagerFragmentDirections
 import kotlinx.android.synthetic.main.onboarding_exposure_fragment.*
@@ -78,6 +79,14 @@ class ExposureNotificationFragment :
 
         setupImage(R.raw.lottie_notifications_05, R.drawable.ic_onboarding_exposure)
         checkSpacing()
+        checkLocalisationRequired()
+    }
+
+    private fun checkLocalisationRequired() {
+        // EN on Android 11 don't require active location
+        if (DeviceUtils.androidVersionAPI >= Build.VERSION_CODES.R) {
+            extendedMessage.gone()
+        }
     }
 
     private fun navigateNext() {

--- a/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/ui/onboarding/fragments/viewpager/ExposureNotificationFragment.kt
@@ -15,12 +15,14 @@
 
 package it.ministerodellasalute.immuni.ui.onboarding.fragments.viewpager
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import it.ministerodellasalute.immuni.R
+import it.ministerodellasalute.immuni.extensions.utils.DeviceUtils
 import it.ministerodellasalute.immuni.extensions.view.setSafeOnClickListener
 import it.ministerodellasalute.immuni.ui.onboarding.fragments.ViewPagerFragmentDirections
 import kotlinx.android.synthetic.main.onboarding_exposure_fragment.*
@@ -64,8 +66,14 @@ class ExposureNotificationFragment :
         }
 
         knowMore.setSafeOnClickListener {
-            val action = ViewPagerFragmentDirections.actionLocalisationExplanation()
-            findNavController().navigate(action)
+            // EN on Android 11 don't require active location
+            if (DeviceUtils.androidVersionAPI >= Build.VERSION_CODES.R) {
+                val action = ViewPagerFragmentDirections.actionHowitworks(false)
+                findNavController().navigate(action)
+            } else {
+                val action = ViewPagerFragmentDirections.actionLocalisationExplanation()
+                findNavController().navigate(action)
+            }
         }
 
         setupImage(R.raw.lottie_notifications_05, R.drawable.ic_onboarding_exposure)

--- a/app/src/main/res/layout/onboarding_exposure_fragment.xml
+++ b/app/src/main/res/layout/onboarding_exposure_fragment.xml
@@ -65,12 +65,12 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="24dp"
                 android:text="@string/onboarding_exposure_permission_description"
-                app:layout_constraintBottom_toTopOf="@+id/textView3"
+                app:layout_constraintBottom_toTopOf="@+id/extendedMessage"
                 app:layout_constraintEnd_toEndOf="@+id/title"
                 app:layout_constraintStart_toStartOf="@+id/title" />
 
             <TextView
-                android:id="@+id/textView3"
+                android:id="@+id/extendedMessage"
                 style="@style/P1Text"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -372,4 +372,5 @@ Betriebssystem: iOS 13.5.1; Modell: iPhone XS; Expositionsmeldungen: Aktiv; [wei
   <string name="support_info_item_lastencheck_none">Keine</string>
   <string name="support_info_item_lastencheck_date" formatted="false">%@ um %@</string>
   <string name="support_info_item_lastencheck_date_android">%1$s um %2$s</string>
+    <string name="exposure_check_in_progress">Kontrolle potenzieller Expositionen im Gange</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -374,4 +374,5 @@ Sistema operativo: iOS 13.5.1; modelo: iPhone XS; notificaciones de exposición:
   <string name="support_info_item_lastencheck_none">Ninguna</string>
   <string name="support_info_item_lastencheck_date" formatted="false">%@ a las %@</string>
   <string name="support_info_item_lastencheck_date_android">%1$s a las %2$s</string>
+    <string name="exposure_check_in_progress">Control de las posibles exposiciones en curso</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -374,4 +374,5 @@ Système d\'exploitation : iOS 13.5.1; Modèle iPhone XS ; Notifications de risq
   <string name="support_info_item_lastencheck_none">Aucune</string>
   <string name="support_info_item_lastencheck_date" formatted="false">%@ à %@</string>
   <string name="support_info_item_lastencheck_date_android">%1$s à %2$s</string>
+    <string name="exposure_check_in_progress">Contrôle des expositions potentielles en cours</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -374,4 +374,5 @@ Sistema operativo: iOS 13.5.1; Modello iPhone XS; Notifiche di esposizione: Atti
   <string name="support_info_item_lastencheck_none">Nessuna</string>
   <string name="support_info_item_lastencheck_date" formatted="false">%@ alle %@</string>
   <string name="support_info_item_lastencheck_date_android">%1$s alle %2$s</string>
+    <string name="exposure_check_in_progress">Controllo potenziali esposizioni in corso</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,6 +74,11 @@
         <item name="android:background">@drawable/bottom_sheet_rounded</item>
     </style>
 
+    <style name="Widget.AppTheme.BottomSheet" parent="Theme.MaterialComponents.BottomSheetDialog">
+        <item name="android:statusBarColor">@color/transparent</item>
+        <item name="android:navigationBarColor">@color/background</item>
+    </style>
+
     <style name="ShapeAppearance.AppTheme.MediumComponent" parent="ShapeAppearance.MaterialComponents.MediumComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">10dp</item>

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         // App version digits
         versionMajor = 1
-        versionMinor = 4
-        versionPatch = 1
+        versionMinor = 5
+        versionPatch = 0
 
         // Version name follows the <major>.<minor>.<patch> convention
         computeVersionName = { ->

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         versionCode = computeVersionCode()
 
         // SDK and tools
-        compileSdkVersion = 29
+        compileSdkVersion = 30
         minSdkVersion = 23
         targetSdkVersion = 29
         buildToolsVersion = "29.0.3"

--- a/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
+++ b/extensions/src/main/java/it/ministerodellasalute/immuni/extensions/nearby/ExposureNotificationManager.kt
@@ -19,6 +19,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
+import android.os.Build
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.nearby.Nearby
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationStatusCodes
@@ -26,6 +27,7 @@ import it.ministerodellasalute.immuni.extensions.bluetooth.BluetoothStateFlow
 import it.ministerodellasalute.immuni.extensions.lifecycle.AppLifecycleObserver
 import it.ministerodellasalute.immuni.extensions.location.LocationStateFlow
 import it.ministerodellasalute.immuni.extensions.nearby.ExposureNotificationClient.*
+import it.ministerodellasalute.immuni.extensions.utils.DeviceUtils
 import it.ministerodellasalute.immuni.extensions.utils.log
 import java.io.File
 import java.util.*
@@ -87,8 +89,12 @@ class ExposureNotificationManager(
             log("isLocationActive $isLocationActive")
             log("isBluetoothActive $isBluetoothActive")
             log("areExposureNotificationsEnabled $areExposureNotificationsEnabled")
-            if (areExposureNotificationsEnabled == null) null
-            else isLocationActive && isBluetoothActive && (areExposureNotificationsEnabled == true)
+            when {
+                areExposureNotificationsEnabled == null -> null
+                // EN on Android 11 don't require active location
+                DeviceUtils.androidVersionAPI >= Build.VERSION_CODES.R -> isBluetoothActive && (areExposureNotificationsEnabled == true)
+                else -> isLocationActive && isBluetoothActive && (areExposureNotificationsEnabled == true)
+            }
         }.conflate().onEach {
             _isBroadcastingActive.value = it
         }.launchIn(scope)


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

On Android 11  users are able to use Exposure Notification apps without turning on the device location setting. See details [here](https://blog.google/inside-google/company-announcements/update-exposure-notifications).

The app doesn't check anymore for active location on Android 11 and up.

The app doesn't display location specific message to the user on Android 11 and up.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
