### PR TITLE
fix: align default settings with the ones returned by the settings API

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
+++ b/app/src/main/java/it/ministerodellasalute/immuni/api/services/ConfigurationSettingsService.kt
@@ -185,7 +185,7 @@ val defaultSettings = ConfigurationSettings(
 
     exposureConfiguration = ExposureConfiguration(
         attenuationThresholds = listOf(50, 70),
-        attenuationScores = listOf(0, 5, 5, 5, 5, 5, 5, 5),
+        attenuationScores = listOf(0, 0, 5, 5, 5, 5, 5, 5),
         daysSinceLastExposureScores = listOf(1, 1, 1, 1, 1, 1, 1, 1),
         durationScores = listOf(0, 0, 0, 0, 5, 5, 5, 5),
         transmissionRiskScores = listOf(1, 1, 1, 1, 1, 1, 1, 1),


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Align default settings with the ones returned by the settings [API](https://get.immuni.gov.it/v1/settings?platform=android&build=1).

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
