### PR TITLE
Add label to inform users that Exposure Notification APIs only work on primary profile

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -72,7 +72,7 @@
   <string name="onboarding_province_title">In welcher Provinz leben Sie?</string>
   <string name="onboarding_province_description">Wählen Sie die Provinz aus, in der Sie leben, damit der staatliche Gesundheitsdienst Sie bestmöglich unterstützen kann.</string>
   <string name="onboarding_exposure_permission_title">So aktivieren Sie COVID-19-Expositionsmeldungen</string>
-  <string name="onboarding_exposure_permission_description">Immuni zeichnet Kontakte mit anderen Nutzern über Bluetooth Low Energy auf, sodass Sie im Falle einer Exposition gegenüber dem Virus informiert werden können. Sie können den Dienst vom Hauptbildschirm aus vorübergehend deaktivieren.</string>
+  <string name="onboarding_exposure_permission_description">Immuni zeichnet Kontakte mit anderen Nutzern über Bluetooth Low Energy auf, sodass Sie im Falle einer Exposition gegenüber dem Virus informiert werden können. Sie können den Dienst vom Hauptbildschirm aus vorübergehend deaktivieren. <b>Dieser Dienst ist nicht verfügbar, wenn Sie Immuni in einem sekundären Profil oder in einem Arbeitsprofil ausführen.</b></string>
   <string name="onboarding_exposure_permission_action">Aktivieren</string>
   <string name="onboarding_exposure_permission_overlay_hint">Tippen Sie auf \"<b>Aktivieren</b>\" in dem Popup-Fenster, das unten angezeigt wird</string>
   <string name="onboarding_bluetooth_off_title">Aktivieren Sie Bluetooth</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -72,7 +72,7 @@
   <string name="onboarding_province_title">¿En qué provincia vives?</string>
   <string name="onboarding_province_description">Selecciona la provincia en la que resides para que el Servicio Nacional de Salud (SSN) pueda asistirte de la mejor forma posible.</string>
   <string name="onboarding_exposure_permission_title">Habilita las notificaciones de exposición a la COVID-19</string>
-  <string name="onboarding_exposure_permission_description">Immuni registra los contactos con otros usuarios a través de Bluetooth Low Energy para poder informarte en caso de exposición al virus. Podrás inhabilitar el servicio de forma temporal desde la pantalla principal.</string>
+  <string name="onboarding_exposure_permission_description">Immuni registra los contactos con otros usuarios a través de Bluetooth Low Energy para poder informarte en caso de exposición al virus. Podrás inhabilitar el servicio de forma temporal desde la pantalla principal. <b>Este servicio no está disponible si está ejecutando Immuni en un perfil secundario o en un perfil de trabajo.</b></string>
   <string name="onboarding_exposure_permission_action">Activar</string>
   <string name="onboarding_exposure_permission_overlay_hint">Selecciona «<b>Activar</b>» en la ventana emergente que aparecerá a continuación</string>
   <string name="onboarding_bluetooth_off_title">Activa el Bluetooth</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,7 +72,7 @@
   <string name="onboarding_province_title">Dans quelle province habitez-vous ?</string>
   <string name="onboarding_province_description">Sélectionnez la province de votre domicile pour aider les services de santé nationaux à vous fournir une meilleure assistance.</string>
   <string name="onboarding_exposure_permission_title">Activez les notifications de risque d\'exposition au COVID-19</string>
-  <string name="onboarding_exposure_permission_description">Immuni enregistre les contacts avec d\'autres utilisateurs en utilisant la technologie Bluetooth Low Energy afin de pouvoir vous informer en cas d\'exposition au virus. Vous pouvez désactiver le service temporairement à partir de la page d\'accueil.</string>
+  <string name="onboarding_exposure_permission_description">Immuni enregistre les contacts avec d\'autres utilisateurs en utilisant la technologie Bluetooth Low Energy afin de pouvoir vous informer en cas d\'exposition au virus. Vous pouvez désactiver le service temporairement à partir de la page d\'accueil. <b>Ce service n\'est pas disponible si vous exécutez Immuni dans un profil secondaire ou dans un profil professionnel.</b></string>
   <string name="onboarding_exposure_permission_action">Activer</string>
   <string name="onboarding_exposure_permission_overlay_hint">Sélectionnez <b>Activer</b> dans la fenêtre contextuelle qui s\'affichera ci-dessous</string>
   <string name="onboarding_bluetooth_off_title">Activez la technologie Bluetooth</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -73,7 +73,7 @@
   <string name="onboarding_province_title">In che provincia vivi?</string>
   <string name="onboarding_province_description">Seleziona la tua provincia di domicilio per aiutare il Servizio Sanitario Nazionale ad assisterti al meglio.</string>
   <string name="onboarding_exposure_permission_title">Abilita le notifiche di esposizione al COVID-19</string>
-  <string name="onboarding_exposure_permission_description">Immuni registra i contatti con altri utenti usando il Bluetooth Low Energy, così da poterti informare in caso di esposizione al virus. Potrai disabilitare il servizio temporaneamente dalla schermata principale.</string>
+  <string name="onboarding_exposure_permission_description">Immuni registra i contatti con altri utenti usando il Bluetooth Low Energy, così da poterti informare in caso di esposizione al virus. Potrai disabilitare il servizio temporaneamente dalla schermata principale. <b>Il servizio non è disponibile se Immuni viene eseguita su un profilo secondario o di lavoro.</b></string>
   <string name="onboarding_exposure_permission_action">Abilita</string>
   <string name="onboarding_exposure_permission_overlay_hint">Seleziona \"<b>Abilita</b>\" nel popup che apparirà qui sotto</string>
   <string name="onboarding_bluetooth_off_title">Attiva il Bluetooth</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
   <string name="onboarding_province_title">Which province do you live in?</string>
   <string name="onboarding_province_description">Select the province where you live to help the National Health Service provide the best possible assistance.</string>
   <string name="onboarding_exposure_permission_title">Enable COVID-19 exposure notifications</string>
-  <string name="onboarding_exposure_permission_description">Immuni uses Bluetooth Low Energy to log contact with other users so that it can inform you if you have been exposed to the virus. You can temporarily disable the service from the home screen.</string>
+  <string name="onboarding_exposure_permission_description">Immuni uses Bluetooth Low Energy to log contact with other users so that it can inform you if you have been exposed to the virus. You can temporarily disable the service from the home screen. <b>This service is not available if you\'re running Immuni in a secondary profile or in a work profile.</b></string>
   <string name="onboarding_exposure_permission_action">Enable</string>
   <string name="onboarding_exposure_permission_overlay_hint">Select \'<b>Enable</b>\' in the pop-up that appears below</string>
   <string name="onboarding_bluetooth_off_title">Turn on Bluetooth</string>


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

As mentioned in #314 users might feel confused when they try to run Immuni in a secondary profile or in a work profile. This PR adds a phrase to inform users that Exposure Notification APIs only work on primary profile

⚠️ This warning is only available for English and Italian languages, I need some help with other translations.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [ ] It is ready for review! :rocket:
