### PR TITLE
feat: switch from pipenv to poetry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
   build:
     description: Perform a build of the Immuni Android application.
     steps:
-      - run: 
+      - run:
           name: "[build] Configure app.properties"
           command: echo $APP_PROPERTIES | base64 --decode > app.properties
       - run:
@@ -104,7 +104,7 @@ commands:
             echo "export BUILD_KIND=$BUILD_KIND" >> $BASH_ENV
 
   check_release_branch:
-    description: Verify if the commit of the build being released is on master. 
+    description: Verify if the commit of the build being released is on master.
     steps:
       - run:
           name: "[release] Stop if not executed on master"
@@ -272,7 +272,7 @@ commands:
 executors:
   default:
     docker:
-      - image: circleci/android:api-29-node
+      - image: cimg/android:2021.10.2-node
     environment:
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
       JVM_OPTS: -Xmx3200m
@@ -348,24 +348,24 @@ jobs:
       - restore_cache:
           name: "[scheduler] Restore Python Cache"
           keys:
-            - pip-packages-v2-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
-            - pip-packages-v2-{{ .Branch }}-
-            - pip-packages-v2-
+            - pip-packages-v3-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
+            - pip-packages-v3-{{ .Branch }}-
+            - pip-packages-v3-
+      - run:
+          name: "[pr_setup] Configure poetry"
+          command: |
+            pip3 install poetry
+            poetry config virtualenvs.in-project true
       - run:
           name: "[scheduler] Install dependencies"
           working_directory: scheduler
-          environment:
-            PIPENV_NOSPIN: 1
-            PIPENV_VENV_IN_PROJECT: 1
-          command: |
-            pip3 install pipenv
-            pipenv install
+          command: poetry install
       - save_cache:
           name: "[scheduler] Save Python Cache"
           paths:
             - ~/.cache/pip
             - scheduler/.venv
-          key: pip-packages-v2-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
+          key: pip-packages-v3-{{ .Branch }}-{{ checksum "scheduler/Pipfile.lock" }}
       - run:
           name: "[scheduler] Configure scheduler"
           command: |
@@ -376,7 +376,7 @@ jobs:
           no_output_timeout: 120m
           command: |
             export REPOSITORY="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-            pipenv run python scheduler.py
+            poetry run python scheduler.py
 
   unit_tests:
     working_directory: ~/code


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR replaces the `pipenv` dependency manager with the `poetry` dependency manager. It also updates the minimum version of Python used to run the scheduler to `3.8` and switches the base CircleCI image to the latest convenience `cimg` image (legacy `circleci` images are going to be deprecated by CircleCI soon).
## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket: